### PR TITLE
Switching from GHCR to DockerHub

### DIFF
--- a/ww-star-deseq2-options.json
+++ b/ww-star-deseq2-options.json
@@ -1,0 +1,10 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": true,
+    "read_from_cache": true,
+    "default_runtime_attributes": {
+        "maxRetries": 1
+    },
+    "final_workflow_outputs_dir": "test-output/",
+    "use_relative_output_paths": true
+}

--- a/ww-star-deseq2.wdl
+++ b/ww-star-deseq2.wdl
@@ -197,7 +197,7 @@ task STARalignTwoPass {
   }
 
   runtime {
-    docker: "ghcr.io/getwilds/star:2.7.6a"
+    docker: "getwilds/star:2.7.6a"
     memory: "62 GB"
     cpu: "8"
   }
@@ -241,7 +241,7 @@ task RNASeQC {
   }
 
   runtime {
-    docker: "ghcr.io/getwilds/rnaseqc:2.4.2"
+    docker: "getwilds/rnaseqc:2.4.2"
     memory: "4 GB"
     cpu: "2"
   }


### PR DESCRIPTION
## Description
- Switching Docker images from GHCR to DockerHub because of call caching issues
- Also adding options json for usability

## Related Issue
- Fixes #2 