### PR TITLE
Add DESeq2 functionality after alignment

### DIFF
--- a/ww-star-deseq2-inputs.json
+++ b/ww-star-deseq2-inputs.json
@@ -3,17 +3,20 @@
     {
       "omics_sample_name": "SRR10724344",
       "R1": "/path_to_first_input/SRR10724344_1.fastq.gz",
-      "R2": "/path_to_first_input/SRR10724344_2.fastq.gz"
+      "R2": "/path_to_first_input/SRR10724344_2.fastq.gz",
+      "condition": "treatment"
     },
     {
       "omics_sample_name": "SRR12345678",
       "R1": "/path_to_second_input/SRR12345678_1.fastq.gz",
-      "R2": "/path_to_second_input/SRR12345678_2.fastq.gz"
+      "R2": "/path_to_second_input/SRR12345678_2.fastq.gz",
+      "condition": "control"
     }
   ],
   "STAR2Pass.reference_genome": {
     "name": "SuperAwesomeGenome",
     "fasta": "/path_to_ref_data/awesome_genome.fna",
     "gtf": "/path_to_ref_data/awesome_transcripts.gtf"
-  }
+  },
+  "STAR2Pass.RunDESeq2.reference_level": "control"
 }

--- a/ww-star-deseq2-inputs.json
+++ b/ww-star-deseq2-inputs.json
@@ -18,5 +18,6 @@
     "fasta": "/path_to_ref_data/awesome_genome.fna",
     "gtf": "/path_to_ref_data/awesome_transcripts.gtf"
   },
-  "STAR2Pass.RunDESeq2.reference_level": "control"
+  "STAR2Pass.reference_level": "control",
+  "STAR2Pass.contrast": "condition,treatment,control"
 }

--- a/ww-star-deseq2-inputs.json
+++ b/ww-star-deseq2-inputs.json
@@ -1,13 +1,13 @@
 {
   "STAR2Pass.samples": [
     {
-      "omics_sample_name": "SRR10724344",
+      "name": "SRR10724344",
       "R1": "/path_to_first_input/SRR10724344_1.fastq.gz",
       "R2": "/path_to_first_input/SRR10724344_2.fastq.gz",
       "condition": "treatment"
     },
     {
-      "omics_sample_name": "SRR12345678",
+      "name": "SRR12345678",
       "R1": "/path_to_second_input/SRR12345678_1.fastq.gz",
       "R2": "/path_to_second_input/SRR12345678_2.fastq.gz",
       "condition": "control"

--- a/ww-star-deseq2.wdl
+++ b/ww-star-deseq2.wdl
@@ -336,7 +336,7 @@ task RunDESeq2 {
   output {
     File deseq2_results = "deseq2_results_all_genes.csv"
     File deseq2_significant = "deseq2_results_significant.csv"
-    File deseq2_normalized_counts = "deseq2_normalized_counts.csv"
+    File deseq2_normalized_counts = "deseq2_results_normalized_counts.csv"
     File deseq2_pca_plot = "deseq2_results_pca.pdf"
     File deseq2_volcano_plot = "deseq2_results_volcano.pdf"
     File deseq2_heatmap = "deseq2_results_heatmap.pdf"

--- a/ww-star-deseq2.wdl
+++ b/ww-star-deseq2.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 struct SampleInfo {
-    String omics_sample_name
+    String name
     File R1
     File R2
     String condition
@@ -41,16 +41,14 @@ workflow STAR2Pass {
   scatter (sample in samples) {
     call STARalignTwoPass {
       input:
-        base_file_name = sample.omics_sample_name,
+        sample_data = sample,
         star_genome_tar = BuildSTARIndex.star_index_tar,
-        r1fastq = sample.R1,
-        r2fastq = sample.R2,
         ref_genome_name = ref_genome_final.name
     }
 
     call RNASeQC {
       input:
-        base_file_name = sample.omics_sample_name,
+        base_file_name = sample.name,
         bam_file = STARalignTwoPass.bam,
         bam_index = STARalignTwoPass.bai,
         ref_gtf = CollapseGTF.collapsed_gtf
@@ -60,7 +58,8 @@ workflow STAR2Pass {
   call CombineCountMatrices {
     input:
       gene_count_files = STARalignTwoPass.geneCounts,
-      samples = samples
+      sample_names = STARalignTwoPass.name,
+      sample_conditions = STARalignTwoPass.condition
   }
 
   call RunDESeq2 {
@@ -81,7 +80,7 @@ workflow STAR2Pass {
     Array[File] output_SJ = STARalignTwoPass.SJout
     Array[File] output_rnaseqc = RNASeQC.rnaseqc_metrics
     File combined_counts_matrix = CombineCountMatrices.counts_matrix
-    File sample_metadata_template = CombineCountMatrices.sample_metadata
+    File sample_metadata = CombineCountMatrices.sample_metadata
     File deseq2_all_results = RunDESeq2.deseq2_results
     File deseq2_significant_results = RunDESeq2.deseq2_significant
     File deseq2_normalized_counts = RunDESeq2.deseq2_normalized_counts
@@ -183,10 +182,8 @@ task CollapseGTF {
 
 task STARalignTwoPass {
   input {
+    SampleInfo sample_data
     File star_genome_tar
-    File r1fastq
-    File r2fastq
-    String base_file_name
     String ref_genome_name
     Int memory_gb = 62
     Int cpu_cores = 8
@@ -202,7 +199,7 @@ task STARalignTwoPass {
     echo "Starting STAR alignment..."
     STAR \
       --genomeDir star_index \
-      --readFilesIn "~{r1fastq}" "~{r2fastq}" \
+      --readFilesIn "~{sample_data.R1}" "~{sample_data.R2}" \
       --runThreadN ~{star_threads} \
       --readFilesCommand zcat \
       --sjdbOverhang 100 \
@@ -215,24 +212,26 @@ task STARalignTwoPass {
 
     rm -r star_index _STARtmp
 
-    mv Aligned.sortedByCoord.out.bam "~{base_file_name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam"
-    mv ReadsPerGene.out.tab "~{base_file_name}.~{ref_genome_name}.ReadsPerGene.out.tab"
-    mv Log.final.out "~{base_file_name}.~{ref_genome_name}.Log.final.out"
-    mv Log.progress.out "~{base_file_name}.~{ref_genome_name}.Log.progress.out"
-    mv Log.out "~{base_file_name}.~{ref_genome_name}.Log.out"
-    mv SJ.out.tab "~{base_file_name}.~{ref_genome_name}.SJ.out.tab"
+    mv Aligned.sortedByCoord.out.bam "~{sample_data.name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam"
+    mv ReadsPerGene.out.tab "~{sample_data.name}.~{ref_genome_name}.ReadsPerGene.out.tab"
+    mv Log.final.out "~{sample_data.name}.~{ref_genome_name}.Log.final.out"
+    mv Log.progress.out "~{sample_data.name}.~{ref_genome_name}.Log.progress.out"
+    mv Log.out "~{sample_data.name}.~{ref_genome_name}.Log.out"
+    mv SJ.out.tab "~{sample_data.name}.~{ref_genome_name}.SJ.out.tab"
 
-    samtools index "~{base_file_name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam"
+    samtools index "~{sample_data.name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam"
   >>>
 
   output {
-    File bam = "~{base_file_name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam"
-    File bai = "~{base_file_name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam.bai"
-    File geneCounts = "~{base_file_name}.~{ref_genome_name}.ReadsPerGene.out.tab"
-    File log_final = "~{base_file_name}.~{ref_genome_name}.Log.final.out"
-    File log_progress = "~{base_file_name}.~{ref_genome_name}.Log.progress.out"
-    File log = "~{base_file_name}.~{ref_genome_name}.Log.out"
-    File SJout = "~{base_file_name}.~{ref_genome_name}.SJ.out.tab"
+    String name = sample_data.name
+    String condition = sample_data.condition
+    File bam = "~{sample_data.name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam"
+    File bai = "~{sample_data.name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam.bai"
+    File geneCounts = "~{sample_data.name}.~{ref_genome_name}.ReadsPerGene.out.tab"
+    File log_final = "~{sample_data.name}.~{ref_genome_name}.Log.final.out"
+    File log_progress = "~{sample_data.name}.~{ref_genome_name}.Log.progress.out"
+    File log = "~{sample_data.name}.~{ref_genome_name}.Log.out"
+    File SJout = "~{sample_data.name}.~{ref_genome_name}.SJ.out.tab"
   }
 
   runtime {
@@ -277,7 +276,8 @@ task RNASeQC {
 task CombineCountMatrices {
   input {
     Array[File] gene_count_files
-    Array[SampleInfo] samples
+    Array[String] sample_names
+    Array[String] sample_conditions
     Int memory_gb = 4
     Int cpu_cores = 1
     # Column to extract from ReadsPerGene.out.tab files:
@@ -292,10 +292,10 @@ task CombineCountMatrices {
 
     combine_star_counts.py \
       --input ~{sep=' ' gene_count_files} \
+      --names ~{sep=' ' sample_names} \
+      --conditions ~{sep=' ' sample_conditions} \
       --output combined_counts_matrix.txt \
-      --metadata sample_metadata.txt \
-      --count_column ~{count_column} \
-      --samples "~{write_json(samples)}"
+      --count_column ~{count_column}
   >>>
 
   output {
@@ -323,7 +323,7 @@ task RunDESeq2 {
 
   command <<<
     set -eo pipefail
-    
+
     Rscript /deseq2_analysis.R \
       --counts_file="~{counts_matrix}" \
       --metadata_file="~{sample_metadata}" \

--- a/ww-star-deseq2.wdl
+++ b/ww-star-deseq2.wdl
@@ -304,7 +304,7 @@ task CombineCountMatrices {
   }
 
   runtime {
-    docker: "ghcr.io/tefirman/combine-counts:latest"
+    docker: "getwilds/combine-counts:latest"
     memory: "~{memory_gb} GB"
     cpu: "~{cpu_cores}"
   }
@@ -343,7 +343,7 @@ task RunDESeq2 {
   }
 
   runtime {
-    docker: "ghcr.io/tefirman/deseq2:latest"
+    docker: "getwilds/deseq2:latest"
     memory: "~{memory_gb} GB"
     cpu: "~{cpu_cores}"
   }


### PR DESCRIPTION
## Description
- Adding basic DESeq2 functionality to the end of the pipeline, see `deseq2` image in [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library/tree/main/deseq2).
- Generates significantly differentially expressed genes and produces PCA, Volcano, and Heatmap plots

## Related Issue
- Fixes #6 

## Testing
- Successfully ran the pipeline using the samples described in [DESeq2's vignette](https://master.bioconductor.org/packages/release/workflows/vignettes/rnaseqGene/inst/doc/rnaseqGene.html#quantifying-with-salmon)
    - [deseq2_results_heatmap.pdf](https://github.com/user-attachments/files/20112215/deseq2_results_heatmap.pdf)
    - [deseq2_results_pca.pdf](https://github.com/user-attachments/files/20112216/deseq2_results_pca.pdf)
    - [deseq2_results_volcano.pdf](https://github.com/user-attachments/files/20112217/deseq2_results_volcano.pdf)
- Will eventually add these samples as a test run, but merging functionality in for now.